### PR TITLE
Adjust background image css, to increase contrast

### DIFF
--- a/single.php
+++ b/single.php
@@ -6,7 +6,8 @@
 				<?php if ( has_post_thumbnail() ) { 
 					$image_data = wp_get_attachment_image_src( get_post_thumbnail_id( $post->ID ), "post-thumbnail" ); ?>
 					<div class="container">
-						<div class="row featured-image" style="background-image:url('<?php echo $image_data[0]; ?>')">
+						
+						<div class="row featured-image" style="background-image:linear-gradient( rgba(0, 0, 0, 0.5), rgba(0, 0, 0, 0.5) ), url('<?php echo $image_data[0]; ?>')">
 							<div class="col-md-6 col-md-offset-2 article-title">
 								<?php the_title('<h1 class="article-title">','</h1>') ?>
 							</div>	    					


### PR DESCRIPTION
This change adds a css `linear-gradient` to add a tint to background images - to increase the contrast, when we have images that use light colours and when we have light text.

All modern browsers should support it, and I think for other browsers the rules are ignored.

Before:

White text against white parts of a background result in low contrast and poor readability.

<img width="1173" alt="Screenshot 2021-02-19 at 11 17 27" src="https://user-images.githubusercontent.com/17906/108491369-1a841980-72a4-11eb-8aba-7938b047876c.png">


After applying the tint means we should always have a minimum amount of contrast, even when backgrounds are light.

<img width="1170" alt="Screenshot 2021-02-19 at 11 16 54" src="https://user-images.githubusercontent.com/17906/108491383-1fe16400-72a4-11eb-95b3-b0c907c412a3.png">

We can adjust this by changing the alpha level from 0.5 if we want it to be darker, or lighter.
